### PR TITLE
Add openkylin test script and interrupted more metadata echo error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+*report.json
+/reports.json
+/summary.md

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-distros = ["openkylin"]
+distros = ["debian", "bianbu"]
 packages = [
     "apache", "clang", "cmake", "docker", "erlang", "gcc", "gdb", "golang", "haproxy", "libmemcached", "lighttpd", "llvm", "mariadb", "nginx", "nodejs", "numpy", "ocaml",
     "openjdk", "perl", "python", "ruby", "rust", "sqlite", "varnish", "openssl", "postgresql", "redis", "runc", "scipy", "squid", "zookeeper"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-distros = ["debian", "bianbu"]
+distros = ["openkylin"]
 packages = [
     "apache", "clang", "cmake", "docker", "erlang", "gcc", "gdb", "golang", "haproxy", "libmemcached", "lighttpd", "llvm", "mariadb", "nginx", "nodejs", "numpy", "ocaml",
     "openjdk", "perl", "python", "ruby", "rust", "sqlite", "varnish", "openssl", "postgresql", "redis", "runc", "scipy", "squid", "zookeeper"

--- a/openkylin/apache/metadata.sh
+++ b/openkylin/apache/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="apache2"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Apache HTTP Server"
+PACKAGE_TYPE="Web Server"
+PACKAGE_DESCRIPTION="Apache HTTP Server"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/apache/test.sh
+++ b/openkylin/apache/test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+PACKAGE_NAME="apache2"
+APACHE_CONF_FILE="/etc/apache2/ports.conf"
+DEFAULT_PORT=80
+
+# 检查端口是否被占用
+is_port_in_use() {
+    local port=$1
+    netstat -tuln | grep -q ":${port} "
+    return $?
+}
+
+# 找到一个随机的可用端口
+find_available_port() {
+    local port
+    while true; do
+        port=$((RANDOM % 65535 + 1024))
+        if ! is_port_in_use $port; then
+            echo $port
+            return
+        fi
+    done
+}
+
+# 更新 Apache 配置使用新的端口
+update_apache_port() {
+    local new_port=$1
+    sed -i "s/Listen $DEFAULT_PORT/Listen $new_port/" $APACHE_CONF_FILE
+    return $?
+}
+
+# 检查 Apache 服务是否正在运行
+is_apache_active() {
+    systemctl is-active --quiet apache2
+    return $?
+}
+
+# 检查 Apache 服务是否启用
+is_apache_enabled() {
+    systemctl is-enabled --quiet apache2
+    return $?
+}
+
+# 检查包是否安装
+is_package_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# 安装 Apache 包
+install_apache_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# 主函数逻辑
+main() {
+    if is_package_installed; then
+        echo "Package $PACKAGE_NAME is installed."
+    else
+        echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+        if install_apache_package; then
+            echo "Package $PACKAGE_NAME installed successfully."
+        else
+            echo "Failed to install package $PACKAGE_NAME."
+            return 1
+        fi
+    fi
+
+    PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+    initial_state_active=$(is_apache_active; echo $?)
+    initial_state_enabled=$(is_apache_enabled; echo $?)
+
+    if is_apache_active; then
+        echo "Apache service is running."
+        exit_status=0
+    else
+        echo "Apache service is not running."
+        if is_port_in_use $DEFAULT_PORT; then
+            echo "Port $DEFAULT_PORT is in use. Finding a new port..."
+            new_port=$(find_available_port)
+            echo "Configuring Apache to use port $new_port..."
+            update_apache_port $new_port
+        fi
+
+        systemctl start apache2
+        if is_apache_active; then
+            echo "Apache service started successfully."
+            exit_status=0
+        else
+            echo "Failed to start Apache service."
+            exit_status=1
+        fi
+    fi
+
+    if [ "$initial_state_active" -eq 0 ]; then
+        systemctl start apache2
+    else
+        systemctl stop apache2
+    fi
+
+    if [ "$initial_state_enabled" -eq 0 ]; then
+        systemctl enable apache2
+    else
+        systemctl disable apache2
+    fi
+
+    echo "Apache service state has been restored."
+}
+
+# 执行主函数
+main
+
+return $exit_status

--- a/openkylin/clang/metadata.sh
+++ b/openkylin/clang/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="clang"
+PACKAGE_VERSION=$(clang --version | grep -oP "version\W?\K.*")
+PACKAGE_PRETTY_NAME="Clang C/C++ Compiler"
+PACKAGE_TYPE="Compiler Toolchain"
+PACKAGE_DESCRIPTION="Clang C/C++ compiler, based on LLVM"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/clang/test.sh
+++ b/openkylin/clang/test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# 检查并安装clang
+check_and_install_clang() {
+    if ! command -v clang &> /dev/null; then
+        echo "clang not found. Attempting to install..."
+        if command -v apt-get &> /dev/null; then
+            export DEBIAN_FRONTEND=noninteractive # 防止apt-get交互式安装
+            apt-get install -y clang
+        elif command -v yum &> /dev/null; then
+            yum install -y clang
+        elif command -v dnf &> /dev/null; then
+            dnf install -y clang
+        elif command -v zypper &> /dev/null; then
+            zypper install -y clang
+        elif command -v pacman &> /dev/null; then
+            pacman -S --noconfirm clang
+        else
+            echo "Unable to install clang. Please install it manually."
+            return 1
+        fi
+    fi
+}
+
+# 执行检查和安装
+check_and_install_clang
+
+# 创建一个简单的C程序
+cat << EOF > test.c
+#include <stdio.h>
+
+int main() {
+    printf("Hello, World!\n");
+    return 0;
+}
+EOF
+
+# 使用clang编译程序
+clang test.c -o test_program
+
+# 检查编译是否成功
+if [ $? -eq 0 ]; then
+    exit_status=0
+else
+    exit_status=1
+fi
+
+# 运行编译后的程序
+./test_program
+
+# 清理临时文件
+rm test.c test_program
+
+PACKAGE_VERSION=$(clang --version | grep -oP "version\W?\K.*")
+
+return $exit_status

--- a/openkylin/cmake/metadata.sh
+++ b/openkylin/cmake/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="cmake"
+PACKAGE_VERSION=$(cmake --version | head -n1 | cut -d' ' -f3)
+PACKAGE_PRETTY_NAME="CMake"
+PACKAGE_TYPE="Build System"
+PACKAGE_DESCRIPTION="Cross-platform make"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/cmake/test.sh
+++ b/openkylin/cmake/test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Check if cmake is installed, if not, install it
+if ! command -v cmake &> /dev/null; then
+    echo "CMake is not installed. Installing..."
+    if [ -x "$(command -v apt-get)" ]; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y cmake
+    elif [ -x "$(command -v yum)" ]; then
+        yum install -y cmake
+    elif [ -x "$(command -v dnf)" ]; then
+        dnf install -y cmake
+    else
+        echo "Unable to install CMake. Please install it manually."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(cmake --version | head -n1 | cut -d' ' -f3)
+CURRENT_DIR=$(pwd)
+
+# Setup temporary test directory
+TEMP_DIR="/tmp/cmake_test_dir"
+mkdir -p "$TEMP_DIR"
+echo "cmake_minimum_required(VERSION 3.10)" > "$TEMP_DIR/CMakeLists.txt"
+echo "project(TestProject)" >> "$TEMP_DIR/CMakeLists.txt"
+echo  "add_executable(test_app main.cpp)" >> "$TEMP_DIR/CMakeLists.txt"
+echo 'int main() { return 0; }' > "$TEMP_DIR/main.cpp"
+
+# Run cmake and make to compile the test project
+cd "$TEMP_DIR" && cmake . && make
+
+# Check if cmake and make succeeded
+if [ -f "$TEMP_DIR/test_app" ]; then
+    if "$TEMP_DIR/test_app"; then
+        return 0
+    else
+        return 1
+    fi
+else
+    return 1
+fi
+
+cd "$CURRENT_DIR"
+
+# Cleanup
+# rm -rf "$TEMP_DIR"

--- a/openkylin/config.toml
+++ b/openkylin/config.toml
@@ -1,11 +1,9 @@
 testing_type = "remote"
-startup_script = "./debian/start_qemu.sh"
-stop_script = "./debian/stop_qemu.sh"
 skip_packages = ["docker"]
 
 [connection]
 method = "ssh"
-ip = "192.168.31.87"
+ip = "localhost"
 port = 22
 username = "openkylin"
 password = "openkylin"

--- a/openkylin/config.toml
+++ b/openkylin/config.toml
@@ -1,0 +1,11 @@
+testing_type = "remote"
+startup_script = "./debian/start_qemu.sh"
+stop_script = "./debian/stop_qemu.sh"
+skip_packages = ["docker"]
+
+[connection]
+method = "ssh"
+ip = "192.168.31.87"
+port = 22
+username = "openkylin"
+password = "openkylin"

--- a/openkylin/docker/metadata.sh
+++ b/openkylin/docker/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="docker-ce"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Docker Engine - Community Edition"
+PACKAGE_TYPE="Container Platform"
+PACKAGE_DESCRIPTION="Docker Engine - Community Edition"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/docker/test.sh
+++ b/openkylin/docker/test.sh
@@ -1,0 +1,131 @@
+# #!/bin/bash
+
+# # Define the package details
+# PACKAGE_NAME="docker-ce"
+# PACKAGE_TYPE="Container Platform"
+# REPORT_FILE="report.json"
+
+# # Function to check if Docker service is active
+# is_docker_active() {
+#     systemctl is-active --quiet docker
+#     return $?
+# }
+
+# # Function to check if a package is installed
+# is_package_installed() {
+#     dpkg -l | grep -qw $PACKAGE_NAME
+#     return $?
+# }
+
+# # Function to install Docker package
+# install_docker_package() {
+#     apt install gpg curl lsb-release apt-transport-https ca-certificates software-properties-common -y
+
+#     # Add Docker's official GPG key
+#     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+#     # Add Docker repository
+#     echo \
+#   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+#   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+#     # Update package index and install Docker
+#     apt-get update
+#     apt-get install -y $PACKAGE_NAME
+#     return $?
+# }
+
+# # Function to generate the report.json
+# generate_report() {
+#     local os_version=$(cat /proc/version)
+#     local kernel_version=$(uname -r)
+#     local package_version=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+#     local test_name="Docker Service Test"
+#     local test_passed=false
+#     local distro="debian"
+
+#     # Check if Docker service is running
+#     if is_docker_active; then
+#         test_passed=true
+#     fi
+
+#     # Prepare the report content
+#     local report_content=$(cat <<EOF
+# {
+#     "distro": "$distro",
+#     "os_version": "$os_version",
+#     "kernel_version": "$kernel_version",
+#     "package_name": "$PACKAGE_NAME",
+#     "package_type": "$PACKAGE_TYPE",
+#     "package_version": "$package_version",
+#     "test_results": [
+#         {
+#             "test_name": "$test_name",
+#             "passed": $test_passed
+#         }
+#     ],
+#     "all_tests_passed": $test_passed
+# }
+# EOF
+# )
+
+#     # Write the report to the file
+#     echo "$report_content" >$REPORT_FILE
+# }
+
+# # Main script execution starts here
+
+# # Check if the package is installed
+# if is_package_installed; then
+#     echo "Package $PACKAGE_NAME is installed."
+# else
+#     echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+#     # Attempt to install the Docker package
+#     if install_docker_package; then
+#         echo "Package $PACKAGE_NAME installed successfully."
+#     else
+#         echo "Failed to install package $PACKAGE_NAME."
+#         exit 1
+#     fi
+# fi
+
+# # Check the initial state of Docker service
+# initial_state_active=$(is_docker_active; echo $?)
+
+# # Check if Docker service is running
+# if is_docker_active; then
+#     echo "Docker service is running."
+#     # Generate the report
+#     generate_report
+#     echo "Report generated at $REPORT_FILE"
+# else
+#     echo "Docker service is not running."
+#     # Try to start Docker service
+#     systemctl start docker
+#     # Check again if Docker service is running
+#     if is_docker_active; then
+#         echo "Docker service started successfully."
+#         # Generate the report
+#         generate_report
+#         echo "Report generated at $REPORT_FILE"
+#     else
+#         echo "Failed to start Docker service."
+#         # Generate the report with test failed
+#         generate_report
+#         echo "Report generated at $REPORT_FILE with failed test."
+#     fi
+# fi
+
+# # Restore the initial state of Docker service
+# if [ "$initial_state_active" -eq 0 ]; then
+#     # If Docker was active initially, ensure it's still active
+#     systemctl start docker
+# else
+#     # If Docker was not active initially, stop it
+#     systemctl stop docker
+# fi
+
+# echo "Docker service state has been restored."
+
+# # End of the script
+echo "Skip docker test"

--- a/openkylin/erlang/metadata.sh
+++ b/openkylin/erlang/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="erlang"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Erlang Programming Language"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="A programming language used to build massively scalable soft real-time systems with requirements on high availability"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/erlang/test.sh
+++ b/openkylin/erlang/test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+export DEBIAN_FRONTEND=noninteractive # 防止apt-get交互式安装
+# 定义包的详细信息
+PACKAGE_NAME="erlang"
+
+# 检查包是否已安装
+is_package_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# 安装 Erlang 包
+install_erlang_package() {
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# 测试 Erlang 的功能
+test_erlang_functionality() {
+    local initial_dir=$(pwd)
+    local temp_dir=$(mktemp -d)
+    local erlang_file="${temp_dir}/hello.erl"
+    local module_name="hello"
+    local erl_output
+
+    # 创建 Erlang 源文件
+    cat <<EOF > "$erlang_file"
+-module($module_name).
+-export([start/0]).
+
+start() ->
+    io:format("Hello, Erlang!~n").
+EOF
+
+    cd "$temp_dir"
+    erl -compile $module_name
+    if [[ -f "${module_name}.beam" ]]; then
+        erl_output=$(erl -noshell -s $module_name start -s init stop)
+        cd "$initial_dir"  # 返回到初始目录
+        if [[ "$erl_output" == "Hello, Erlang!" ]]; then
+            return 0
+        fi
+    fi
+    cd "$initial_dir"  # 返回到初始目录
+    return 1
+}
+
+
+# 主函数逻辑
+main() {
+    # 检查包是否已安装
+    if is_package_installed; then
+        echo "Package $PACKAGE_NAME is installed."
+    else
+        echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+        if install_erlang_package; then
+            echo "Package $PACKAGE_NAME installed successfully."
+        else
+            echo "Failed to install package $PACKAGE_NAME."
+            return 1
+        fi
+    fi
+
+    PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+    # 测试 Erlang 的功能
+    if test_erlang_functionality; then
+        echo "Erlang is functioning correctly."
+        return 0
+    else
+        echo "Erlang is not functioning correctly."
+        return 1
+    fi
+}
+
+# 执行主函数
+main

--- a/openkylin/example/test.sh
+++ b/openkylin/example/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# PACKAGE_VERSION needs to be specified as a global variable, either manually or through commands
+# It could be defined anywhere in the script (I think); just make sure you defined it in every script
+PACKAGE_VERSION="1.0.0-justatest"
+# PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+echo "This is an example dummy test script..."
+
+# Do your stuff here
+sleep 1
+
+# Do NOT use "exit" at all times; use "return" instead, 
+# otherwise the PACKAGE_VERSION could not be fetched properly in report.json
+
+# note that when used in sub-functions, "return" may only be able to jump out of the function,
+# not exiting from the script itself. If a main function is used, consider adding
+# related checks there to ensure that the script will exit on error.
+return 0

--- a/openkylin/gcc/Makefile
+++ b/openkylin/gcc/Makefile
@@ -1,0 +1,48 @@
+PACKAGE_NAME := gcc
+PACKAGE_VERSION := $(shell apt-cache policy $(PACKAGE_NAME) | grep Installed | awk '{print $$2}')
+OS_VERSION := $(shell uname -v)
+KERNEL_VERSION := $(shell uname -r)
+
+# Temporary directory for tests
+TEMP_DIR := ./temp
+
+# Test script
+GENERATE_REPORT_SCRIPT := ./run_tests.sh
+
+.PHONY: clean test check_dependencies verify_gcc generate_report install_gcc
+
+# Clean up temporary files
+clean:
+	@rm -rf $(TEMP_DIR)
+
+# Check for GCC and install if not present
+check_dependencies: install_gcc
+
+install_gcc:
+	@echo "Checking for GCC and dependencies..."
+	@command -v gcc >/dev/null 2>&1 || { \
+		echo "GCC is not installed. Installing GCC..."; \
+		sudo apt update && sudo apt install -y gcc; \
+		if [ $$? -ne 0 ]; then \
+			echo "Failed to install GCC. Please check your package manager settings."; \
+			exit 1; \
+		fi \
+	} && echo "GCC is installed."
+
+# Verify GCC by compiling a simple program
+verify_gcc:
+	@echo "Verifying GCC..."
+	@mkdir -p $(TEMP_DIR)
+	@echo 'int main() { return 0; }' > $(TEMP_DIR)/test.c
+	@! gcc $(TEMP_DIR)/test.c -o $(TEMP_DIR)/test && { \
+		echo "GCC compilation failed. Please check your GCC installation."; \
+		exit 1; \
+	} || echo "GCC verification passed."
+
+# Generate a report
+generate_report:
+	@$(GENERATE_REPORT_SCRIPT) $(TEMP_DIR)/test
+
+# Main test target
+test: clean check_dependencies verify_gcc generate_report
+	@echo "Tests completed."

--- a/openkylin/gcc/metadata.sh
+++ b/openkylin/gcc/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="gcc"
+PACKAGE_VERSION=$(gcc --version | head -n1 | cut -d' ' -f4)
+PACKAGE_PRETTY_NAME="GNU Compiler Collection"
+PACKAGE_TYPE="Compiler Toolchain"
+PACKAGE_DESCRIPTION="The GNU Compiler Collection"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/gcc/run_tests.sh
+++ b/openkylin/gcc/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Check if the test executable exists and is executable
+if [ -x "$1" ]; then
+    TEST_RESULT=$($1)
+    return $?
+else
+    return 1
+fi

--- a/openkylin/gcc/test.sh
+++ b/openkylin/gcc/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+PACKAGE_VERSION=$(gcc --version | head -n1 | cut -d' ' -f4)
+make test
+rm -rf ./temp

--- a/openkylin/gdb/metadata.sh
+++ b/openkylin/gdb/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="gdb"
+PACKAGE_VERSION=$(gdb --version | head -n1)
+PACKAGE_PRETTY_NAME="GNU Debugger"
+PACKAGE_TYPE="Debugging Tool"
+PACKAGE_DESCRIPTION="The GNU Debugger"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/gdb/test.sh
+++ b/openkylin/gdb/test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="gdb"
+
+# Function to check if GDB is installed
+is_gdb_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install GDB package
+install_gdb_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to check GDB version and functionality
+test_gdb_functionality() {
+    PACKAGE_VERSION=$(gdb --version | head -n1)
+    if [[ -n $PACKAGE_VERSION ]]; then
+        echo "$PACKAGE_VERSION"
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if GDB is installed
+if is_gdb_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the GDB package
+    if install_gdb_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+# Check GDB functionality
+if test_gdb_functionality; then
+    echo "GDB is functioning correctly."
+    return 0
+else
+    echo "GDB is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/golang/metadata.sh
+++ b/openkylin/golang/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="golang-go"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Go Programming Language"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="Go programming language compiler, linker, and libraries"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/golang/test.sh
+++ b/openkylin/golang/test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="golang-go"
+
+# Function to check if Go is installed
+is_go_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install Go package
+install_go_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to compile a simple Go program and test functionality
+test_go_functionality() {
+    local temp_dir=$(mktemp -d)
+    local go_file="${temp_dir}/hello.go"
+    local executable="${temp_dir}/hello"
+
+    # Write a simple Go program to test compilation
+    cat <<EOF > "$go_file"
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+EOF
+
+    # Compile the Go program
+    go build -o "$executable" "$go_file"
+
+    # Check if the executable was created and runs without error
+    if [[ -x "$executable" && "$($executable)" == "Hello, World!" ]]; then
+        echo "Go program compiled and ran successfully."
+        return 0
+    else
+        echo "Failed to compile or run Go program."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Go is installed
+if is_go_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the Go package
+    if install_go_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+# Check Go functionality by compiling a simple Go program
+if test_go_functionality; then
+    echo "Go is functioning correctly."
+    return 0
+else
+    echo "Go is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/haproxy/metadata.sh
+++ b/openkylin/haproxy/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="haproxy"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | awk '{print $3}')
+PACKAGE_PRETTY_NAME="HAProxy"
+PACKAGE_TYPE="Load Balancer"
+PACKAGE_DESCRIPTION="Reliable, high performance TCP/HTTP load balancer"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/haproxy/test.sh
+++ b/openkylin/haproxy/test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="haproxy"
+
+# Function to check if HAProxy is installed
+is_haproxy_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install HAProxy package
+install_haproxy_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to check HAProxy service status
+test_haproxy_service() {
+    systemctl is-active --quiet haproxy
+    return $?
+}
+
+# Function to start HAProxy service
+start_haproxy_service() {
+    systemctl start haproxy
+    return $?
+}
+
+# Main script execution starts here
+
+# Check if HAProxy is installed
+if is_haproxy_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the HAProxy package
+    if install_haproxy_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | awk '{print $3}')
+# Check HAProxy service status
+if test_haproxy_service; then
+    echo "HAProxy service is active."
+    return 0
+else
+    echo "HAProxy service is not active. Attempting to start the service..."
+    # Attempt to start the HAProxy service
+    if start_haproxy_service; then
+        echo "HAProxy service started successfully."
+        # Recheck HAProxy service status
+        if test_haproxy_service; then
+            echo "HAProxy service is now active."
+            return 0
+        else
+            echo "Failed to start HAProxy service."
+            return 1
+        fi
+    else
+        echo "Failed to start HAProxy service."
+        return 1
+    fi
+fi
+
+# End of the script

--- a/openkylin/libmemcached/metadata.sh
+++ b/openkylin/libmemcached/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="libmemcached11t64"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="libmemcached"
+PACKAGE_TYPE="Caching Library"
+PACKAGE_DESCRIPTION="Client library to memcached servers (transitional package)"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/libmemcached/test.sh
+++ b/openkylin/libmemcached/test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# 定义包的详细信息
+PACKAGE_NAME="libmemcached11t64"
+PACKAGE_DEV_NAME="libmemcached-dev"
+MEMCACHED_PACKAGE="memcached"
+
+# 检查包是否已安装
+is_package_installed() {
+    dpkg -l | grep -qw $1
+    return $?
+}
+
+# 安装 libmemcached 和 memcached 包
+install_libmemcached_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME $PACKAGE_DEV_NAME $MEMCACHED_PACKAGE
+    return $?
+}
+
+# 启动 memcached 服务
+start_memcached() {
+    memcached -d -m 64 -p 11211 -u memcache
+    return $?
+}
+
+# 停止 memcached 服务
+stop_memcached() {
+    pkill memcached
+    return $?
+}
+
+# 测试 libmemcached 的功能
+test_libmemcached_functionality() {
+    local initial_dir=$(pwd)
+    local temp_dir=$(mktemp -d)
+    local test_file="${temp_dir}/test_libmemcached.c"
+    local executable="${temp_dir}/test_libmemcached"
+    local memcached_server="localhost"
+
+    # 写一个简单的 C 程序来测试 libmemcached 功能
+    cat <<EOF > "$test_file"
+#include <stdio.h>
+#include <string.h>
+#include <libmemcached/memcached.h>
+
+int main() {
+    memcached_st *memc;
+    memcached_server_st *servers;
+    memcached_return rc;
+    char *retrieved_value;
+    size_t value_length;
+    uint32_t flags;
+
+    memc = memcached_create(NULL);
+    servers = memcached_server_list_append(NULL, "$memcached_server", 11211, &rc);
+    rc = memcached_server_push(memc, servers);
+    if (rc != MEMCACHED_SUCCESS) {
+        fprintf(stderr, "Couldn't add server: %s\\n", memcached_strerror(memc, rc));
+        return 1;
+    }
+
+    const char *key = "key";
+    const char *value = "value";
+    rc = memcached_set(memc, key, strlen(key), value, strlen(value), (time_t)0, (uint32_t)0);
+    if (rc != MEMCACHED_SUCCESS) {
+        fprintf(stderr, "Couldn't store key: %s\\n", memcached_strerror(memc, rc));
+        return 1;
+    }
+
+    retrieved_value = memcached_get(memc, key, strlen(key), &value_length, &flags, &rc);
+    if (rc != MEMCACHED_SUCCESS) {
+        fprintf(stderr, "Couldn't retrieve key: %s\\n", memcached_strerror(memc, rc));
+        return 1;
+    }
+
+    printf("Retrieved value: %s\\n", retrieved_value);
+    free(retrieved_value);
+    memcached_free(memc);
+
+    return 0;
+}
+EOF
+
+    # 编译 C 程序
+    gcc "$test_file" -o "$executable" -lmemcached
+
+    # 检查可执行文件是否创建并运行无错误
+    if [[ -x "$executable" ]]; then
+        "$executable"
+        local result=$?
+        cd "$initial_dir"  # 返回到初始目录
+        return $result
+    else
+        cd "$initial_dir"  # 返回到初始目录
+        return 1
+    fi
+}
+
+# 主函数逻辑
+main() {
+    # 检查包是否已安装
+    if is_package_installed $PACKAGE_NAME; then
+        echo "Package $PACKAGE_NAME is installed."
+    else
+        echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+        if install_libmemcached_package; then
+            echo "Package $PACKAGE_NAME installed successfully."
+        else
+            echo "Failed to install package $PACKAGE_NAME."
+            return 1
+        fi
+    fi
+
+    PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+    # 启动 memcached 服务
+    if command -v memcached &> /dev/null; then
+        if start_memcached; then
+            echo "memcached service started successfully."
+        else
+            echo "Failed to start memcached service."
+            return 1
+        fi
+    else
+        echo "memcached command not found. Please ensure memcached is installed correctly."
+        return 1
+    fi
+
+    # 测试 libmemcached 的功能
+    if test_libmemcached_functionality; then
+        echo "libmemcached is functioning correctly."
+        return 0
+    else
+        echo "libmemcached is not functioning correctly."
+        return 0
+    fi
+
+    # 停止 memcached 服务
+    stop_memcached
+    echo "memcached service stopped."
+}
+
+# 执行主函数
+main

--- a/openkylin/lighttpd/metadata.sh
+++ b/openkylin/lighttpd/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="lighttpd"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Lighttpd"
+PACKAGE_TYPE="Web Server"
+PACKAGE_DESCRIPTION="Lighttpd - a secure, fast, compliant and very flexible web server"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/lighttpd/test.sh
+++ b/openkylin/lighttpd/test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="lighttpd"
+
+# Function to check if Lighttpd is installed
+is_lighttpd_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install Lighttpd package
+install_lighttpd_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to test Lighttpd service status
+test_lighttpd_service() {
+    local curl_response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost)
+    if [[ $curl_response -eq 200 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Lighttpd is installed
+if is_lighttpd_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the Lighttpd package
+    if install_lighttpd_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+# Check Lighttpd service status by connecting to the default port
+if test_lighttpd_service; then
+    echo "Lighttpd service is active and responding."
+    return 0
+else
+    echo "Lighttpd service is active but not responding."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/llvm/metadata.sh
+++ b/openkylin/llvm/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="llvm"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="LLVM Compiler Infrastructure"
+PACKAGE_TYPE="Compiler Toolchain"
+PACKAGE_DESCRIPTION="The LLVM Compiler Infrastructure"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/llvm/test.sh
+++ b/openkylin/llvm/test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="llvm"
+
+# Function to check if LLVM is installed
+is_llvm_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install LLVM package
+install_llvm_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME clang
+    return $?
+}
+
+# Function to compile a simple C program and test functionality
+test_llvm_functionality() {
+    local temp_dir=$(mktemp -d)
+    local c_file="${temp_dir}/hello.c"
+    local executable="${temp_dir}/hello"
+
+    # Write a simple C program to test compilation
+    cat <<EOF > "$c_file"
+#include <stdio.h>
+
+int main() {
+    printf("Hello, LLVM!\n");
+    return 0;
+}
+EOF
+
+    # Compile the C program with LLVM
+    clang "$c_file" -o "${executable}"
+
+    # Check if the executable was created and runs without error
+    if [[ -x "$executable" && "$("${executable}")" == "Hello, LLVM!" ]]; then
+        echo "LLVM is functioning correctly."
+        return 0
+    else
+        echo "Failed to compile or run LLVM test program."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if LLVM is installed
+if is_llvm_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the LLVM package
+    if install_llvm_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+# Check LLVM functionality by compiling and running a simple C program
+if test_llvm_functionality; then
+    echo "LLVM is functioning correctly."
+    return 0
+else
+    echo "LLVM is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/mariadb/metadata.sh
+++ b/openkylin/mariadb/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="mariadb-server"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="MariaDB database server"
+PACKAGE_TYPE="Database"
+PACKAGE_DESCRIPTION="MariaDB database server binaries"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/mariadb/test.sh
+++ b/openkylin/mariadb/test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="mariadb-server"
+
+# Function to check if MariaDB is installed
+is_mariadb_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install MariaDB package
+install_mariadb_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to test MariaDB service status
+test_mariadb_service() {
+    local mysql_status=$(mysqladmin ping --host=localhost --user=root --password=root)
+    if [[ $mysql_status == "mysqld is alive" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if MariaDB is installed
+if is_mariadb_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the MariaDB package
+    if install_mariadb_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+            exit 1
+        else
+            return 1
+        fi
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+# Check MariaDB service status
+if test_mariadb_service; then
+    echo "MariaDB service is active and responding."
+        if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+            exit 0
+        else
+            return 0
+        fi
+else
+    echo "MariaDB service is active but not responding."
+        if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+            exit 1
+        else
+            return 1
+        fi
+fi
+
+# End of the script

--- a/openkylin/nginx/metadata.sh
+++ b/openkylin/nginx/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="nginx"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Nginx"
+PACKAGE_TYPE="Web Server"
+PACKAGE_DESCRIPTION="high-performance web server and a reverse proxy server"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/nginx/test.sh
+++ b/openkylin/nginx/test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="nginx"
+
+# Function to check if Nginx is installed
+is_nginx_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install Nginx package
+install_nginx_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to test Nginx service status
+test_nginx_service() {
+    local curl_response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost)
+    if [[ $curl_response -eq 200 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Nginx is installed
+if is_nginx_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    # Attempt to install the Nginx package
+    if install_nginx_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+# Check Nginx service status by connecting to the default port
+if test_nginx_service; then
+    echo "Nginx service is active and responding."
+    return 0
+else
+    echo "Nginx service is active but not responding."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/nodejs/metadata.sh
+++ b/openkylin/nodejs/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="nodejs"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Node.js"
+PACKAGE_TYPE="Javascript Runtime"
+PACKAGE_DESCRIPTION="Evented I/O for V8 JavaScript - runtime executable"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/nodejs/test.sh
+++ b/openkylin/nodejs/test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+PACKAGE_NAME="nodejs"
+
+is_nodejs_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+install_nodejs_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+test_nodejs_functionality() {
+    local temp_dir=$(mktemp -d)
+    echo "Temp dir: $temp_dir"
+
+    local js_file="${temp_dir}/hello.js"
+
+    cat <<EOF > "$js_file"
+console.log('Hello, Node.js!');
+EOF
+
+    local output=$(node "$js_file")
+    if [[ "$output" == "Hello, Node.js!" ]]; then
+        echo "Node.js is functioning correctly."
+        return 0
+    else
+        echo "Failed to run Node.js test program correctly."
+        return 1
+    fi
+}
+
+if is_nodejs_installed; then
+    echo "Package $PACKAGE_NAME is installed."
+else
+    echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+    if install_nodejs_package; then
+        echo "Package $PACKAGE_NAME installed successfully."
+    else
+        echo "Failed to install package $PACKAGE_NAME."
+        return 1
+    fi
+fi
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+if test_nodejs_functionality; then
+    echo "Node.js is functioning correctly."
+    return 0
+else
+    echo "Node.js is not functioning correctly."
+    return 1
+fi

--- a/openkylin/numpy/metadata.sh
+++ b/openkylin/numpy/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="python3-numpy"
+PACKAGE_VERSION="$(python3 --version) ($(python3 -c "import numpy; print(numpy.__version__)"))"
+PACKAGE_PRETTY_NAME="NumPy"
+PACKAGE_TYPE="Python Library"
+PACKAGE_DESCRIPTION="Numerical Python adds a fast array facility to the Python language"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/numpy/test.sh
+++ b/openkylin/numpy/test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="python3-numpy"
+
+# Function to check if Python 3 is installed
+is_python3_installed() {
+    dpkg -l | grep -qw python3-full
+    return $?
+}
+
+# Function to check if NumPy is installed
+is_numpy_installed() {
+    python3 -c "import numpy" 2>/dev/null
+    return $?
+}
+
+# Function to install Python 3 package
+install_python3_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y python3-full
+    apt-get install -y python-is-python3 python3-pip
+    return $?
+}
+
+# Function to install NumPy
+install_numpy() {
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to test Numpy functionality
+test_numpy_functionality() {
+    local temp_dir=$(mktemp -d)
+    local python_file="${temp_dir}/test_numpy.py"
+    local output_file="${temp_dir}/numpy_output.txt"
+
+    # Write a simple Python script to test Numpy functionality
+    cat <<EOF > "$python_file"
+import numpy as np
+
+print(np.array([1, 2, 3]))
+EOF
+
+    # Run the Python script with Numpy
+    python "$python_file" > "$output_file"
+
+    # Check if the script ran successfully and the output is as expected
+    if [[ -f "$output_file" && "$(cat "$output_file")" == "[1 2 3]" ]]; then
+        echo "Numpy is functioning correctly."
+        return 0
+    else
+        echo "Failed to run Numpy test script."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Python 3 is installed
+if is_python3_installed; then
+    echo "Python 3 is installed."
+else
+    echo "Python 3 is not installed. Attempting to install..."
+    # Attempt to install the Python 3 package
+    if install_python3_package; then
+        echo "Python 3 installed successfully."
+    else
+        echo "Failed to install Python 3."
+        exit 1
+    fi
+fi
+
+# Check if NumPy is installed
+if is_numpy_installed; then
+    echo "NumPy is installed."
+else
+    echo "NumPy is not installed. Attempting to install..."
+    # Attempt to install NumPy
+    if install_numpy; then
+        echo "NumPy installed successfully."
+    else
+        echo "Failed to install NumPy."
+        exit 1
+    fi
+fi
+
+PACKAGE_VERSION="$(python3 --version) ($(python3 -c "import numpy; print(numpy.__version__)"))"
+echo "Python and NumPy versions: $PACKAGE_VERSION"
+
+# Check Numpy functionality by compiling and running a simple Python script
+if test_numpy_functionality; then
+    echo "Numpy is functioning correctly."
+    exit 0
+else
+    echo "Numpy is not functioning correctly."
+    exit 1
+fi
+
+# End of the script

--- a/openkylin/ocaml/metadata.sh
+++ b/openkylin/ocaml/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="ocaml"
+PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+PACKAGE_PRETTY_NAME="Objective Caml"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="The Objective Caml compiler"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/ocaml/test.sh
+++ b/openkylin/ocaml/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+PACKAGE_NAME="ocaml"
+
+# 检查 OCaml 是否已安装
+is_ocaml_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# 安装 OCaml 包
+install_ocaml_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME ocamlbuild
+    return $?
+}
+
+# 测试 OCaml 的功能
+test_ocaml_functionality() {
+    local initial_dir=$(pwd)
+    local temp_dir=$(mktemp -d)
+    local ocaml_file="${temp_dir}/hello.ml"
+    local executable="${temp_dir}/hello"
+
+    # 创建 OCaml 源文件
+    cat <<EOF > "$ocaml_file"
+let () = print_endline "Hello, OCaml!"
+EOF
+
+    cd "$temp_dir"
+    ocamlc -o hello hello.ml
+
+    if [[ -x "$executable" ]]; then
+        local output=$("$executable")
+        cd "$initial_dir"  # 返回到初始目录
+        if [[ "$output" == "Hello, OCaml!" ]]; then
+            return 0
+        fi
+    fi
+    cd "$initial_dir"  # 返回到初始目录
+    return 1
+}
+
+# 主函数逻辑
+main() {
+    if is_ocaml_installed; then
+        echo "Package $PACKAGE_NAME is installed."
+    else
+        echo "Package $PACKAGE_NAME is not installed. Attempting to install..."
+        if install_ocaml_package; then
+            echo "Package $PACKAGE_NAME installed successfully."
+        else
+            echo "Failed to install package $PACKAGE_NAME."
+            return 1
+        fi
+    fi
+
+    PACKAGE_VERSION=$(dpkg -l | grep $PACKAGE_NAME | head -n 1 | awk '{print $3}')
+
+    if test_ocaml_functionality; then
+        echo "OCaml is functioning correctly."
+        return 0
+    else
+        echo "OCaml is not functioning correctly."
+        return 1
+    fi
+}
+
+# 执行主函数
+main

--- a/openkylin/openjdk/metadata.sh
+++ b/openkylin/openjdk/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="openjdk-11-jdk"
+PACKAGE_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+PACKAGE_PRETTY_NAME="OpenJDK Development Kit (JDK)"
+PACKAGE_TYPE="Java Development Kit"
+PACKAGE_DESCRIPTION="OpenJDK Development Kit (JDK)"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/openjdk/test.sh
+++ b/openkylin/openjdk/test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="openjdk-11-jdk"
+PACKAGE_SHOW_NAME="OpenJDK"
+PACKAGE_TYPE="Java Development Kit"
+REPORT_FILE="report.json"
+
+# Function to check if OpenJDK is installed
+is_openjdk_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install OpenJDK package
+install_openjdk_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+
+    return $?
+}
+
+# Function to test OpenJDK functionality
+test_openjdk_functionality() {
+    local temp_dir=$(mktemp -d)
+    local java_file="${temp_dir}/TestJava.java"
+    local class_file="${temp_dir}/TestJava.class"
+    local output_file="${temp_dir}/java_output.txt"
+
+    # Write a simple Java program to test OpenJDK functionality
+    cat <<EOF > "$java_file"
+public class TestJava {
+    public static void main(String[] args) {
+        System.out.println("OpenJDK is working!");
+    }
+}
+EOF
+
+    # Compile the Java file
+    javac "$java_file"
+
+    # Check if compilation was successful
+    if [ ! -f "$class_file" ]; then
+        echo "Failed to compile Java test file."
+        return 1
+    fi
+
+    # Run the compiled Java program
+    java -cp "$temp_dir" TestJava > "$output_file"
+
+    # Check if the program ran successfully and the output is as expected
+    if [[ -f "$output_file" && "$(cat "$output_file")" == "OpenJDK is working!" ]]; then
+        echo "OpenJDK is functioning correctly."
+        return 0
+    else
+        echo "Failed to run OpenJDK test program."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if OpenJDK is installed
+if is_openjdk_installed; then
+    echo "OpenJDK is installed."
+else
+    echo "OpenJDK is not installed. Attempting to install..."
+    # Attempt to install the OpenJDK package
+    if install_openjdk_package; then
+        echo "OpenJDK installed successfully."
+    else
+        echo "Failed to install OpenJDK."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+
+# Check OpenJDK functionality by compiling and running a simple Java program
+if test_openjdk_functionality; then
+    echo "OpenJDK is functioning correctly."
+    return 0
+else
+    echo "OpenJDK is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/openssl/metadata.sh
+++ b/openkylin/openssl/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="openssl"
+PACKAGE_VERSION=$(openssl version | awk '{print $2}')
+PACKAGE_PRETTY_NAME="OpenSSL"
+PACKAGE_TYPE="Cryptography Library"
+PACKAGE_DESCRIPTION="Secure Sockets Layer toolkit - cryptographic utility"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/openssl/test.sh
+++ b/openkylin/openssl/test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="openssl"
+
+# Function to check if OpenSSL is installed
+is_openssl_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install OpenSSL package
+install_openssl_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+
+    return $?
+}
+
+# Function to test OpenSSL functionality
+test_openssl_functionality() {
+    local temp_dir=$(mktemp -d)
+    local test_file="${temp_dir}/test.txt"
+    local encrypted_file="${temp_dir}/test.enc"
+    local decrypted_file="${temp_dir}/test.dec"
+
+    # Create a test file
+    echo "OpenSSL test message" > "$test_file"
+
+    # Encrypt the file
+    openssl enc -aes-256-cbc -salt -in "$test_file" -out "$encrypted_file" -pass pass:testpassword
+
+    # Decrypt the file
+    openssl enc -d -aes-256-cbc -in "$encrypted_file" -out "$decrypted_file" -pass pass:testpassword
+
+    # Check if the decrypted content matches the original
+    if diff "$test_file" "$decrypted_file" >/dev/null; then
+        echo "OpenSSL encryption and decryption test passed."
+        return 0
+    else
+        echo "OpenSSL encryption and decryption test failed."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if OpenSSL is installed
+if is_openssl_installed; then
+    echo "OpenSSL is installed."
+else
+    echo "OpenSSL is not installed. Attempting to install..."
+    # Attempt to install the OpenSSL package
+    if install_openssl_package; then
+        echo "OpenSSL installed successfully."
+    else
+        echo "Failed to install OpenSSL."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(openssl version | awk '{print $2}')
+# Check OpenSSL functionality by performing encryption and decryption
+if test_openssl_functionality; then
+    echo "OpenSSL is functioning correctly."
+    return 0
+else
+    echo "OpenSSL is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/perl/metadata.sh
+++ b/openkylin/perl/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="perl"
+PACKAGE_VERSION=$(perl -v | grep -oP "v\K(\d+\.\d+\.\d+)")
+PACKAGE_PRETTY_NAME="Perl"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="Larry Wall's Practical Extraction and Report Language"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/perl/test.sh
+++ b/openkylin/perl/test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="perl"
+
+# Function to check if Perl is installed
+is_perl_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install Perl package
+install_perl_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+
+    return $?
+}
+
+# Function to test Perl functionality
+test_perl_functionality() {
+    local temp_dir=$(mktemp -d)
+    local perl_file="${temp_dir}/test.pl"
+    local output_file="${temp_dir}/perl_output.txt"
+
+    # Write a simple Perl script to test functionality
+    cat <<'EOF' > "$perl_file"
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my @array = (1, 2, 3, 4, 5);
+my $sum = 0;
+$sum += $_ for @array;
+print "The sum is: $sum\n";
+EOF
+
+    # Run the Perl script
+    perl "$perl_file" > "$output_file"
+
+    # Check if the script ran successfully and the output is as expected
+    if [[ -f "$output_file" && "$(cat "$output_file")" == "The sum is: 15" ]]; then
+        echo "Perl is functioning correctly."
+        return 0
+    else
+        echo "Failed to run Perl test script."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Perl is installed
+if is_perl_installed; then
+    echo "Perl is installed."
+else
+    echo "Perl is not installed. Attempting to install..."
+    # Attempt to install the Perl package
+    if install_perl_package; then
+        echo "Perl installed successfully."
+    else
+        echo "Failed to install Perl."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(perl -v | grep -oP "v\K(\d+\.\d+\.\d+)")
+
+# Check Perl functionality by running a simple Perl script
+if test_perl_functionality; then
+    echo "Perl is functioning correctly."
+    return 0
+else
+    echo "Perl is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/postgresql/metadata.sh
+++ b/openkylin/postgresql/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="postgresql"
+PACKAGE_VERSION=$(psql --version | awk '{print $3}')
+PACKAGE_PRETTY_NAME="PostgreSQL"
+PACKAGE_TYPE="Database"
+PACKAGE_DESCRIPTION="Object-relational SQL database, version 16 server"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/postgresql/test.sh
+++ b/openkylin/postgresql/test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="postgresql"
+
+# Function to check if PostgreSQL is installed
+is_postgresql_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install PostgreSQL package
+install_postgresql_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME postgresql-contrib
+    systemctl start postgresql
+    systemctl enable postgresql
+    return $?
+}
+
+# Function to test PostgreSQL functionality
+test_postgresql_functionality() {
+    local test_db="test_db"
+    local test_user="test_user"
+    local test_password="test_password"
+
+    # Create a test user and database
+    sudo -u postgres psql -c "CREATE USER $test_user WITH PASSWORD '$test_password';"
+    sudo -u postgres createdb -O $test_user $test_db
+
+    # Run a test query
+    local query_result=$(PGPASSWORD=$test_password psql -h localhost -U $test_user -d $test_db -t -c "SELECT 1 AS result;")
+
+    # Clean up
+    sudo -u postgres dropdb $test_db
+    sudo -u postgres psql -c "DROP USER $test_user;"
+
+    # Check if the query was successful
+    if [ "$(echo $query_result | tr -d ' ')" = "1" ]; then
+        echo "PostgreSQL is functioning correctly."
+        return 0
+    else
+        echo "Failed to run PostgreSQL test query."
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if PostgreSQL is installed
+if is_postgresql_installed; then
+    echo "PostgreSQL is installed."
+else
+    echo "PostgreSQL is not installed. Attempting to install..."
+    # Attempt to install the PostgreSQL package
+    if install_postgresql_package; then
+        echo "PostgreSQL installed successfully."
+    else
+        echo "Failed to install PostgreSQL."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(psql --version | awk '{print $3}')
+
+# Check PostgreSQL functionality by running a simple query
+if test_postgresql_functionality; then
+    echo "PostgreSQL is functioning correctly."
+    return 0
+else
+    echo "PostgreSQL is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/prerequisite.sh
+++ b/openkylin/prerequisite.sh
@@ -1,0 +1,2 @@
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y sudo curl apt-transport-https ca-certificates gnupg lsb-release netcat-openbsd

--- a/openkylin/python/metadata.sh
+++ b/openkylin/python/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="python3"
+PACKAGE_VERSION=$(python3 --version | awk '{print $2}')
+PACKAGE_PRETTY_NAME="Python 3"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="Interactive high-level object-oriented language (default python3 version)"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/python/test.sh
+++ b/openkylin/python/test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="python3"
+
+# Function to check if Python is installed
+is_python_installed() {
+    command -v python3 >/dev/null 2>&1
+    return $?
+}
+
+# Function to install Python package
+install_python_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y python3 python3-pip
+    return $?
+}
+
+# Function to test Python functionality
+test_python_functionality() {
+    local temp_dir=$(mktemp -d)
+    local python_file="${temp_dir}/test.py"
+    local output_file="${temp_dir}/python_output.txt"
+
+    # Write a simple Python script to test functionality
+    cat <<EOF > "$python_file"
+import sys
+import math
+
+def test_basic_operations():
+    assert 2 + 2 == 4, "Basic addition failed"
+    assert 10 - 5 == 5, "Basic subtraction failed"
+    assert 3 * 4 == 12, "Basic multiplication failed"
+    assert 15 / 3 == 5, "Basic division failed"
+
+def test_string_operations():
+    assert "hello " + "world" == "hello world", "String concatenation failed"
+    assert "python".upper() == "PYTHON", "String upper() method failed"
+
+def test_list_operations():
+    lst = [1, 2, 3]
+    lst.append(4)
+    assert lst == [1, 2, 3, 4], "List append failed"
+
+def test_math_operations():
+    assert math.sqrt(16) == 4, "Math square root failed"
+    assert math.pi > 3.14 and math.pi < 3.15, "Math pi constant failed"
+
+if __name__ == "__main__":
+    test_basic_operations()
+    test_string_operations()
+    test_list_operations()
+    test_math_operations()
+    print("All tests passed successfully!")
+EOF
+
+    # Run the Python script
+    python3 "$python_file" > "$output_file" 2>&1
+
+    # Check if the script ran successfully and the output is as expected
+    if [[ -f "$output_file" && "$(cat "$output_file")" == "All tests passed successfully!" ]]; then
+        echo "Python is functioning correctly."
+        return 0
+    else
+        echo "Failed to run Python test script."
+        cat "$output_file"  # Print the actual output for debugging
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Python is installed
+if is_python_installed; then
+    echo "Python is installed."
+else
+    echo "Python is not installed. Attempting to install..."
+    # Attempt to install the Python package
+    if install_python_package; then
+        echo "Python installed successfully."
+    else
+        echo "Failed to install Python."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(python3 --version | awk '{print $2}')
+
+# Check Python functionality by running a test script
+if test_python_functionality; then
+    echo "Python is functioning correctly."
+    return 0
+else
+    echo "Python is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/redis/metadata.sh
+++ b/openkylin/redis/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="redis-server"
+PACKAGE_VERSION=$(redis-server --version | awk '{print $3}' | cut -d '=' -f2)
+PACKAGE_PRETTY_NAME="Redis"
+PACKAGE_TYPE="Database"
+PACKAGE_DESCRIPTION="Persistent key-value database, server side"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/redis/test.sh
+++ b/openkylin/redis/test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="redis-server"
+
+# Function to check if Redis is installed
+is_redis_installed() {
+    dpkg -l | grep -qw $PACKAGE_NAME
+    return $?
+}
+
+# Function to install Redis package
+install_redis_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    systemctl start redis-server
+    systemctl enable redis-server
+    return $?
+}
+
+# Function to test Redis functionality
+test_redis_functionality() {
+    local test_key="test_key"
+    local test_value="test_value"
+
+    # Set a key-value pair
+    redis-cli SET $test_key $test_value > /dev/null
+
+    # Get the value
+    local retrieved_value=$(redis-cli GET $test_key)
+
+    # Delete the key
+    redis-cli DEL $test_key > /dev/null
+
+    # Check if the retrieved value matches the set value
+    if [ "$retrieved_value" = "$test_value" ]; then
+        echo "Redis is functioning correctly."
+        return 0
+    else
+        echo "Failed to perform Redis operations."
+        echo "Retrieved value: $retrieved_value"
+        echo "Expected value: $test_value"
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Redis is installed
+if is_redis_installed; then
+    echo "Redis is installed."
+else
+    echo "Redis is not installed. Attempting to install..."
+    # Attempt to install the Redis package
+    if install_redis_package; then
+        echo "Redis installed successfully."
+    else
+        echo "Failed to install Redis."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(redis-server --version | awk '{print $3}' | cut -d '=' -f2)
+
+# Check Redis functionality by performing basic operations
+if test_redis_functionality; then
+    echo "Redis is functioning correctly."
+    return 0
+else
+    echo "Redis is not functioning correctly."
+    return 1
+fi
+
+# End of the script

--- a/openkylin/ruby/metadata.sh
+++ b/openkylin/ruby/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="ruby"
+PACKAGE_VERSION=$(ruby --version | awk '{print $2}')
+PACKAGE_PRETTY_NAME="Ruby"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="Interpreter of object-oriented scripting language Ruby"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/ruby/test.sh
+++ b/openkylin/ruby/test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Define the package details
+PACKAGE_NAME="ruby"
+
+# Function to check if Ruby is installed
+is_ruby_installed() {
+    command -v ruby >/dev/null 2>&1
+    return $?
+}
+
+# Function to install Ruby package
+install_ruby_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y $PACKAGE_NAME
+    return $?
+}
+
+# Function to test Ruby functionality
+test_ruby_functionality() {
+    local temp_dir=$(mktemp -d)
+    local ruby_file="${temp_dir}/test.rb"
+    local output_file="${temp_dir}/ruby_output.txt"
+
+    # Write a simple Ruby script to test functionality
+    cat <<EOF > "$ruby_file"
+# Test basic arithmetic
+raise "Basic arithmetic failed" unless 2 + 2 == 4
+
+# Test string manipulation
+raise "String manipulation failed" unless "hello".capitalize == "Hello"
+
+# Test array operations
+arr = [1, 2, 3]
+arr << 4
+raise "Array operations failed" unless arr == [1, 2, 3, 4]
+
+# Test hash operations
+hash = { "a" => 1, "b" => 2 }
+hash["c"] = 3
+raise "Hash operations failed" unless hash == { "a" => 1, "b" => 2, "c" => 3 }
+
+# Test basic file I/O
+File.write("./test_file.txt", "Hello, Ruby!")
+content = File.read("./test_file.txt")
+raise "File I/O failed" unless content == "Hello, Ruby!"
+
+puts "All tests passed successfully!"
+EOF
+
+    # Run the Ruby script
+    ruby "$ruby_file" > "$output_file" 2>&1
+
+    # Check if the script ran successfully and the output is as expected
+    if [[ -f "$output_file" && "$(cat "$output_file")" == "All tests passed successfully!" ]]; then
+        echo "Ruby is functioning correctly."
+        return 0
+    else
+        echo "Failed to run Ruby test script."
+        cat "$output_file"  # Print the actual output for debugging
+        return 1
+    fi
+}
+
+# Main script execution starts here
+
+# Check if Ruby is installed
+if is_ruby_installed; then
+    echo "Ruby is installed."
+else
+    echo "Ruby is not installed. Attempting to install..."
+    # Attempt to install the Ruby package
+    if install_ruby_package; then
+        echo "Ruby installed successfully."
+    else
+        echo "Failed to install Ruby."
+        return 1
+    fi
+fi
+
+PACKAGE_VERSION=$(ruby --version | awk '{print $2}')
+
+# Check Ruby functionality by running a test script
+if test_ruby_functionality; then
+    echo "Ruby is functioning correctly."
+    exit_status=0
+else
+    echo "Ruby is not functioning correctly."
+    exit_status=1
+fi
+
+rm test_file.txt
+return $exit_status
+# End of the script

--- a/openkylin/runc/metadata.sh
+++ b/openkylin/runc/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="runc"
+PACKAGE_VERSION=$(runc --version | awk '/runc version/{print $3}')
+PACKAGE_PRETTY_NAME="runc"
+PACKAGE_TYPE="Container Runtime"
+PACKAGE_DESCRIPTION="CLI tool for spawning and running containers according to the OCI specification"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/runc/test.sh
+++ b/openkylin/runc/test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Define the package details
+PACKAGE_NAME="runc"
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Function to check if runc is installed
+is_runc_installed() {
+    if command -v runc >/dev/null 2>&1; then
+        log "runC is installed."
+        return 0
+    else
+        log "runC is not installed."
+        return 1
+    fi
+}
+
+# Function to install runc package
+install_runc_package() {
+    export DEBIAN_FRONTEND=noninteractive
+    log "Attempting to install runC..."
+    if ! apt-get update; then
+        echo "Failed to update package lists."
+        return 1
+    fi
+    if ! apt-get install -y runc; then
+        echo "Failed to install runC."
+        return 1
+    fi
+    log "runC installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+
+    # Check if running as root
+    if [[ $EUID -ne 0 ]]; then
+        echo "This script must be run as root."
+        return 1
+    fi
+
+    # Check kernel version
+    local kernel_version
+    kernel_version=$(uname -r)
+    log "Kernel version: $kernel_version"
+
+    # Check /proc mount
+    if ! mount | grep -q "proc on /proc type proc"; then
+        log "WARNING: /proc is not mounted correctly. Attempting to remount..."
+        if ! mount -t proc proc /proc; then
+            echo "Failed to mount /proc."
+            return 1
+        fi
+    fi
+
+    # Check namespaces support
+    if [[ ! -d /proc/self/ns ]]; then
+        log "ERROR: /proc/self/ns directory not found."
+        log "Kernel namespaces configuration:"
+        grep CONFIG_NAMESPACES /boot/config-"$(uname -r)" || log "Unable to find namespace configuration"
+        log "Contents of /proc/self:"
+        ls -l /proc/self || log "Unable to list /proc/self"
+        echo "Namespace support is not available."
+        return 1
+    fi
+
+    # Check specific namespaces
+    for ns in ipc mnt net pid user uts; do
+        if [[ ! -e /proc/self/ns/$ns ]]; then
+            log "WARNING: $ns namespace is not available"
+        fi
+    done
+
+    # Check cgroups support
+    if [[ ! -d /sys/fs/cgroup ]]; then
+        echo "Cgroups are not available."
+        return 1
+    fi
+
+    # Check unshare command
+    if ! unshare --fork --pid --mount-proc sleep 1; then
+        log "WARNING: unshare command failed. This might indicate issues with namespace support."
+    fi
+
+    log "System prerequisites check completed."
+}
+
+# Function to test runc functionality
+test_runc_functionality() {
+    local temp_dir
+    temp_dir=$(mktemp -d) || error_exit "Failed to create temporary directory."
+    log "Created temporary directory: $temp_dir"
+
+    local bundle_dir="${temp_dir}/bundle"
+    local rootfs_dir="${bundle_dir}/rootfs"
+
+    mkdir -p "$rootfs_dir" || error_exit "Failed to create rootfs directory."
+
+    # Create a simple config.json
+    cat > "${bundle_dir}/config.json" <<EOF
+{
+    "ociVersion": "1.0.1-dev",
+    "process": {
+        "terminal": false,
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "args": [
+            "echo",
+            "Hello from runc!"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "cwd": "/"
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "linux": {
+        "namespaces": [
+            {"type": "pid"},
+            {"type": "ipc"},
+            {"type": "uts"},
+            {"type": "mount"}
+        ]
+    }
+}
+EOF
+
+    log "Created config.json in $bundle_dir"
+
+    # Run the container
+    log "Attempting to run runc container..."
+    if ! output=$(runc run --bundle "$bundle_dir" test-container 2>&1); then
+        log "Failed to run runc container. Output:"
+        log "$output"
+        rm -rf "$temp_dir"
+        return 1
+    fi
+
+    log "Container output: $output"
+
+    # Clean up
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+
+    # Check if the output is as expected
+    if [[ "$output" == "Hello from runc!" ]]; then
+        log "runC test passed successfully."
+        return 0
+    else
+        log "Unexpected output from runc container."
+        return 1
+    fi
+}
+
+# Main script execution
+main() {
+    log "Starting runC test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_runc_installed; then
+        if ! install_runc_package; then
+            return 1
+        fi
+    fi
+
+    PACKAGE_VERSION=$(runc --version | awk '/runc version/{print $3}') || PACKAGE_VERSION="Unknown"
+    
+    if test_runc_functionality; then
+        log "runC is functioning correctly."
+        return 0
+    else
+        log "runC is not functioning correctly."
+        return 1
+    fi
+}
+
+# Run the main function
+main

--- a/openkylin/rust/metadata.sh
+++ b/openkylin/rust/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="rustc"
+PACKAGE_VERSION=$(rustc --version | awk '{print $2}')
+PACKAGE_PRETTY_NAME="Rust"
+PACKAGE_TYPE="Programming Language"
+PACKAGE_DESCRIPTION="Rust compiler"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/rust/test.sh
+++ b/openkylin/rust/test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="rust"
+
+# Function to check if Rust is installed
+is_rust_installed() {
+    if command -v rustc >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1; then
+        log "Rust is installed."
+        return 0
+    else
+        log "Rust is not installed."
+        return 1
+    fi
+}
+
+# Function to install Rust
+install_rust() {
+    log "Attempting to install Rust..."
+    if ! curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; then
+        echo "Failed to install Rust."
+        return 1
+    fi
+    source $HOME/.cargo/env
+    log "Rust installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+
+    # Check for curl
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "curl is not installed. Please install curl and try again."
+        return 1
+    fi
+
+    # Check for gcc
+    if ! command -v gcc >/dev/null 2>&1; then
+        echo "gcc is not installed. Please install build-essential and try again."
+        return 1
+    fi
+
+    log "System prerequisites check passed."
+}
+
+# Function to test Rust functionality
+test_rust_functionality() {
+    local temp_dir
+    temp_dir=$(mktemp -d) || error_exit "Failed to create temporary directory."
+    log "Created temporary directory: $temp_dir"
+
+    cd "$temp_dir"
+
+    # Create a new Rust project
+    log "Creating a new Rust project..."
+    if ! cargo new hello_world; then
+        rm -rf "$temp_dir"
+        echo "Failed to create Rust project."
+        return 1
+    fi
+
+    cd hello_world
+
+    # Build the project
+    log "Building the Rust project..."
+    if ! cargo build; then
+        rm -rf "$temp_dir"
+        echo "Failed to build Rust project."
+        return 1
+    fi
+
+    # Run the project
+    log "Running the Rust project..."
+    if ! output=$(cargo run 2>&1); then
+        log "Failed to run Rust project. Output:"
+        log "$output"
+        rm -rf "$temp_dir"
+        return 1
+    fi
+
+    log "Project output: $output"
+
+    # Clean up
+    cd ..
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+
+    # After cleaning up:
+    log "Cleaned up temporary directory."
+    cd "$original_dir"
+    log "Changed back to original directory: $original_dir"
+
+    # Check if the output is as expected
+    if [[ "$output" == *"Hello, world!"* ]]; then
+        log "Rust test passed successfully."
+        return 0
+    else
+        log "Unexpected output from Rust project."
+        return 1
+    fi
+}
+
+# Main script execution
+main() {
+    log "Starting Rust test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_rust_installed; then
+        if ! install_rust; then
+            return 1
+        fi
+    fi
+
+    local rust_version=$(rustc --version | awk '{print $2}') || rust_version="Unknown"
+    local cargo_version=$(cargo --version | awk '{print $2}') || cargo_version="Unknown"
+    PACKAGE_VERSION="$rust_version ($cargo_version)"
+
+    if test_rust_functionality; then
+        log "Rust is functioning correctly."
+        return 0
+    else
+        log "Rust is not functioning correctly."
+        return 1
+    fi
+}
+
+# Run the main function
+main

--- a/openkylin/scipy/metadata.sh
+++ b/openkylin/scipy/metadata.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PACKAGE_NAME="python3-scipy"
+python_version=$(python3 --version | awk '{print $2}')
+scipy_version=$(python3 -c "import scipy; print(scipy.__version__)")
+PACKAGE_VERSION="$scipy_version (python $python_version)"
+PACKAGE_PRETTY_NAME="SciPy"
+PACKAGE_TYPE="Python Library"
+PACKAGE_DESCRIPTION="Scientific Tools for Python"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/scipy/test.sh
+++ b/openkylin/scipy/test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="python3-scipy"
+
+# Function to check if Python 3 and SciPy are installed
+is_scipy_installed() {
+    if python3 -c "import scipy" >/dev/null 2>&1; then
+        log "SciPy is installed."
+        return 0
+    else
+        log "SciPy is not installed."
+        return 1
+    fi
+}
+
+# Function to install SciPy
+install_scipy() {
+    log "Attempting to install SciPy..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    if ! apt-get install -y python3-scipy; then
+        echo "Failed to install SciPy."
+        return 1
+    fi
+    log "SciPy installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+
+    # Check for Python 3
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "Python 3 is not installed. Please install Python 3 and try again."
+        return 1
+    fi
+
+    log "System prerequisites check passed."
+}
+
+# Function to test SciPy functionality
+test_scipy_functionality() {
+    local temp_dir
+    temp_dir=$(mktemp -d) || (echo "Failed to create temporary directory." && return 1)
+    log "Created temporary directory: $temp_dir"
+
+    cd "$temp_dir"
+
+    # Create a simple SciPy test script
+    cat <<EOF > test_scipy.py
+import scipy
+import numpy as np
+from scipy import stats
+
+# Generate some random data
+data = np.random.randn(1000)
+
+# Compute the mean and standard deviation
+mean = np.mean(data)
+std = np.std(data)
+
+# Perform a one-sample t-test
+t_statistic, p_value = stats.ttest_1samp(data, 0)
+
+print(f"Mean: {mean:.4f}")
+print(f"Standard Deviation: {std:.4f}")
+print(f"T-statistic: {t_statistic:.4f}")
+print(f"P-value: {p_value:.4f}")
+EOF
+
+    # Run the SciPy test script
+    log "Running the SciPy test script..."
+    if ! output=$(python3 test_scipy.py 2>&1); then
+        log "Failed to run SciPy test script. Output:"
+        log "$output"
+        rm -rf "$temp_dir"
+        return 1
+    fi
+
+    log "Script output:"
+    log "$output"
+
+    # Clean up
+    cd ..
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+
+    # After cleaning up:
+    cd "$original_dir"
+    log "Changed back to original directory: $original_dir"
+
+    # Check if the output contains expected elements
+    if [[ "$output" == *"Mean:"* && "$output" == *"Standard Deviation:"* && "$output" == *"T-statistic:"* && "$output" == *"P-value:"* ]]; then
+        log "SciPy test passed successfully."
+        return 0
+    else
+        log "Unexpected output from SciPy test script."
+        return 1
+    fi
+}
+
+# Main script execution
+main() {
+    log "Starting SciPy test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_scipy_installed; then
+        if ! install_scipy; then
+            return 1
+        fi
+    fi
+
+    local python_version=$(python3 --version | awk '{print $2}') || python_version="Unknown"
+    local scipy_version=$(python3 -c "import scipy; print(scipy.__version__)") || scipy_version="Unknown"
+    PACKAGE_VERSION="$scipy_version (python $python_version)"
+    if test_scipy_functionality; then
+        log "SciPy is functioning correctly."
+        return 0
+    else
+        log "SciPy is not functioning correctly."
+        return 1
+    fi
+}
+
+# Run the main function
+main

--- a/openkylin/sqlite/metadata.sh
+++ b/openkylin/sqlite/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="sqlite3"
+PACKAGE_VERSION=$(sqlite3 --version | awk '{print $1}')
+PACKAGE_PRETTY_NAME="SQLite 3"
+PACKAGE_TYPE="Database"
+PACKAGE_DESCRIPTION="Command-line interface for SQLite 3"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/sqlite/test.sh
+++ b/openkylin/sqlite/test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="sqlite3"
+
+# Function to check if SQLite is installed
+is_sqlite_installed() {
+    if command -v sqlite3 >/dev/null 2>&1; then
+        log "SQLite is installed."
+        return 0
+    else
+        log "SQLite is not installed."
+        return 1
+    fi
+}
+
+# Function to install SQLite
+install_sqlite() {
+    log "Attempting to install SQLite..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y sqlite3
+    
+    if ! is_sqlite_installed; then
+        echo "SQLite installation failed. The 'sqlite3' command is still not available."
+        return 1
+    fi
+
+    log "SQLite installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+    # No specific prerequisites for SQLite
+    log "System prerequisites check passed."
+}
+
+# Function to test SQLite functionality
+test_sqlite_functionality() {
+    local db_file="test.db"
+    local output
+
+    log "Creating test database..."
+    sqlite3 "$db_file" <<EOF
+CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+INSERT INTO test (name) VALUES ('Alice');
+INSERT INTO test (name) VALUES ('Bob');
+SELECT * FROM test;
+.quit
+EOF
+
+    log "Querying test database..."
+    output=$(sqlite3 "$db_file" "SELECT * FROM test;")
+
+    log "Database output:"
+    log "$output"
+
+    # Check if the output contains expected data
+    if [[ "$output" == *"1|Alice"* && "$output" == *"2|Bob"* ]]; then
+        log "SQLite test passed successfully."
+        return 0
+    else
+        log "Unexpected output from SQLite test."
+        return 1
+    fi
+}
+
+# Main script execution
+main() {
+    log "Starting SQLite test script..."
+
+    
+    if ! check_prerequisites; then
+        return 1;
+    fi
+
+    if ! is_sqlite_installed; then
+        if ! install_sqlite; then
+            return 1;
+        fi
+    fi
+
+    PACKAGE_VERSION=$(sqlite3 --version | awk '{print $1}') || PACKAGE_VERSION="Unknown"
+
+    # Clean up
+    cd "$original_dir"
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+
+
+    if test_sqlite_functionality; then
+        log "SQLite is functioning correctly."
+        return 0
+    else
+        log "SQLite is not functioning correctly."
+        return 1
+    fi
+}
+
+# Run the main function
+main
+rm test.db

--- a/openkylin/squid/metadata.sh
+++ b/openkylin/squid/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="squid"
+PACKAGE_VERSION=$(squid -v | head -n1 | awk '{print $4}')
+PACKAGE_PRETTY_NAME="Squid"
+PACKAGE_TYPE="Proxy Server"
+PACKAGE_DESCRIPTION="Caching Proxy for the Web"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/squid/test.sh
+++ b/openkylin/squid/test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="squid"
+
+# Function to check if Squid is installed
+is_squid_installed() {
+    if command -v squid >/dev/null 2>&1; then
+        log "Squid is installed. Path: $(which squid)"
+        return 0
+    else
+        log "Squid is not installed."
+        return 1
+    fi
+}
+
+# Function to install Squid
+install_squid() {
+    log "Attempting to install Squid..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    if ! apt-get install -y squid; then
+        echo "Failed to install Squid."
+        return 1
+    fi
+    log "Squid installation command completed. Verifying installation..."
+    if ! is_squid_installed; then
+        echo "Squid installation failed. The 'squid' command is still not available."
+        return 1
+    fi
+    log "Squid installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+    # No specific prerequisites for Squid
+    log "System prerequisites check passed."
+}
+
+# Function to test Squid functionality
+test_squid_functionality() {
+    log "Starting Squid service..."
+    if ! sudo systemctl start squid; then
+        log "Failed to start Squid service."
+        return 1
+    fi
+
+    log "Checking Squid service status..."
+    if ! sudo systemctl is-active --quiet squid; then
+        log "Squid service is not active."
+        return 1
+    fi
+
+    log "Testing Squid configuration..."
+    if ! sudo squid -k parse; then
+        log "Squid configuration test failed."
+        return 1
+    fi
+
+    log "Stopping Squid service..."
+    if ! sudo systemctl stop squid; then
+        log "Failed to stop Squid service."
+        return 1
+    fi
+
+    log "Squid functionality test passed successfully."
+    return 0
+}
+
+# Main script execution
+main() {
+    log "Starting Squid test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_squid_installed; then
+        if ! install_squid; then
+            return 1
+        fi
+    fi
+
+    log "Verifying Squid installation again..."
+    if ! is_squid_installed; then
+        echo "Squid installation verification failed."
+        return 1
+    fi
+
+    PACKAGE_VERSION=$(squid -v | head -n1 | awk '{print $4}') || PACKAGE_VERSION="Unknown"
+
+    cd "$original_dir"
+    if test_squid_functionality; then
+        log "Squid is functioning correctly."
+        return 0
+    else
+        log "Squid is not functioning correctly."
+        return 1
+    fi
+}
+
+# Run the main function
+main
+
+# Clean up
+rm -rf "$temp_dir"
+log "Cleaned up temporary directory."
+log "Squid test script completed."

--- a/openkylin/start_qemu.sh
+++ b/openkylin/start_qemu.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Define the directory and the script to execute
+SCRIPT_DIR="../dqib_riscv64-virt/"  # Replace with the directory containing boot.sh
+STARTUP_SCRIPT="boot.sh"
+USER="root"
+PASSWORD="root"
+PORT=2222
+ADDRESS="localhost"
+
+# Function to check if sshpass is installed
+check_sshpass() {
+    if ! command -v sshpass &> /dev/null; then
+        echo "sshpass is not installed. Please install it to proceed."
+        exit 1
+    fi
+}
+
+# Function to check if SSH connection is possible
+check_ssh_connection() {
+    if sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$USER@$ADDRESS" -p "$PORT" "exit" &> /dev/null; then
+        echo "Successfully connected to QEMU via SSH."
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to start QEMU in the background
+start_qemu() {
+    # Change to the directory containing the boot script and execute it in a new bash session
+    bash -c "cd $SCRIPT_DIR && nohup ./$STARTUP_SCRIPT > qemu.log 2>&1 &" &
+}
+
+# Function to wait for QEMU to start and become accessible via SSH
+wait_for_qemu() {
+    local retries=20
+    local delay=5
+
+    for ((i=0; i<$retries; i++)); do
+        if check_ssh_connection; then
+            echo "QEMU has started and is accessible via SSH."
+            return 0
+        fi
+        echo "QEMU not accessible via SSH yet. Retrying in $delay seconds..."
+        sleep $delay
+    done
+
+    echo "Failed to connect to QEMU via SSH after multiple attempts."
+    exit 1
+}
+
+# Main script execution starts here
+
+# Check if sshpass is installed
+check_sshpass
+
+# Check if SSH connection is possible
+if check_ssh_connection; then
+    echo "Already connected to QEMU via SSH. Exiting..."
+    exit 0
+fi
+
+# Start QEMU in the background
+start_qemu
+
+# Wait for QEMU to start and become accessible via SSH
+wait_for_qemu
+
+# The QEMU process should be running by now. Exit this script but keep QEMU running.
+exit 0

--- a/openkylin/start_ssh.sh
+++ b/openkylin/start_ssh.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# the following environmental variables should be controlled directly from TestEnvManager
+# USER="root"
+# PASSWORD="root"
+# PORT=2222
+# ADDRESS="localhost"
+
+# echo $USER
+# echo $PASSWORD
+# echo $PORT
+# echo $ADDRESS
+
+# Function to check if sshpass is installed
+check_sshpass() {
+    if ! command -v sshpass &> /dev/null; then
+        echo "sshpass is not installed. Please install it to proceed."
+        exit 1
+    fi
+}
+
+# Function to check if SSH connection is possible
+check_ssh_connection() {
+    if sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$USER@$ADDRESS" -p "$PORT" "exit" &> /dev/null; then
+        echo "Able to establish SSH connection."
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to wait for environment to start and become accessible via SSH
+wait_for_connection() {
+    local retries=20
+    local delay=5
+
+    for ((i=0; i<$retries; i++)); do
+        if check_ssh_connection; then
+            echo "Environment is accessible via SSH."
+            return 0
+        fi
+        echo "Environment not connected yet. Retrying in $delay seconds..."
+        sleep $delay
+    done
+
+    echo "Failed to connect to environment via SSH."
+    exit 1
+}
+
+# Main script execution starts here
+
+# Check if sshpass is installed
+check_sshpass
+
+# Check if SSH connection is possible
+if check_ssh_connection; then
+    echo "Already connected to environment via SSH. Exiting..."
+    exit 0
+fi
+
+
+# Wait for environment to become accessible via SSH
+wait_for_connection
+
+exit 0

--- a/openkylin/stop_qemu.sh
+++ b/openkylin/stop_qemu.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Define the SSH connection parameters
+USER="root"
+PASSWORD="root"
+PORT=2222
+ADDRESS="localhost"
+
+# Function to check if sshpass is installed
+check_sshpass() {
+    if ! command -v sshpass &> /dev/null; then
+        echo "sshpass is not installed. Please install it to proceed."
+        exit 1
+    fi
+}
+
+# Function to stop QEMU via SSH
+stop_qemu_ssh() {
+    local retries=3
+    local delay=5
+
+    for ((i=0; i<$retries; i++)); do
+        if sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$USER@$ADDRESS" -p "$PORT" "halt" &> /dev/null; then
+            echo "Successfully sent halt command to QEMU via SSH."
+            return 0
+        fi
+        echo "Failed to send halt command. Retrying in $delay seconds..."
+        sleep $delay
+    done
+
+    echo "Failed to stop QEMU via SSH after multiple attempts."
+    return 1
+}
+
+# Function to kill QEMU processes
+kill_qemu_processes() {
+    echo "Killing QEMU processes on the local machine."
+    pkill -f qemu-system-riscv64
+}
+
+# Main script execution starts here
+
+# Check if sshpass is installed
+check_sshpass
+
+# Attempt to stop QEMU via SSH
+if ! stop_qemu_ssh; then
+    # If SSH halt command fails, force kill QEMU processes
+    kill_qemu_processes
+fi
+
+# Exit the script
+exit 0

--- a/openkylin/stop_ssh.sh
+++ b/openkylin/stop_ssh.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Define the SSH connection parameters
+# USER="root"
+# PASSWORD="root"
+# PORT=2222
+# ADDRESS="localhost"
+
+# Function to check if sshpass is installed
+check_sshpass() {
+    if ! command -v sshpass &> /dev/null; then
+        echo "sshpass is not installed. Please install it to proceed."
+        exit 1
+    fi
+}
+
+# Function to stop environment via SSH
+stop_environment_ssh() {
+    local retries=3
+    local delay=5
+
+    for ((i=0; i<$retries; i++)); do
+        if sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$USER@$ADDRESS" -p "$PORT" "halt" &> /dev/null; then
+            echo "Successfully sent halt command to environment via SSH."
+            return 0
+        fi
+        echo "Failed to send halt command. Retrying in $delay seconds..."
+        sleep $delay
+    done
+
+    echo "Failed to stop environment via SSH after multiple attempts."
+    return 1
+}
+
+
+# Main script execution starts here
+
+# Check if sshpass is installed
+check_sshpass
+
+stop_environment_ssh
+
+# Exit the script
+exit 0

--- a/openkylin/varnish/metadata.sh
+++ b/openkylin/varnish/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="varnish"
+PACKAGE_VERSION=$(varnishd -V 2>&1 | grep -oP 'varnish-\K\d+\.\d+\.\d+' | head -1)
+PACKAGE_PRETTY_NAME="Varnish Cache"
+PACKAGE_TYPE="Caching Server"
+PACKAGE_DESCRIPTION="High-performance HTTP accelerator"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/varnish/test.sh
+++ b/openkylin/varnish/test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="varnish"
+
+# Function to check if Varnish is installed
+is_varnish_installed() {
+    if command -v varnishd >/dev/null 2>&1; then
+        log "Varnish is installed. Path: $(which varnishd)"
+        return 0
+    else
+        log "Varnish is not installed."
+        return 1
+    fi
+}
+
+# Function to install Varnish
+install_varnish() {
+    log "Attempting to install Varnish..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    if ! apt-get install -y varnish; then
+        echo "Failed to install Varnish."
+        return 1
+    fi
+    log "Varnish installation command completed. Verifying installation..."
+    if ! is_varnish_installed; then
+        echo "Varnish installation failed. The 'varnishd' command is still not available."
+        return 1
+    fi
+    log "Varnish installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+    # No specific prerequisites for Varnish
+    log "System prerequisites check passed."
+}
+
+# Function to test Varnish functionality
+test_varnish_functionality() {
+    log "Starting Varnish service..."
+    if ! systemctl start varnish; then
+        log "Failed to start Varnish service."
+        return 1
+    fi
+
+    log "Checking Varnish service status..."
+    if ! systemctl is-active --quiet varnish; then
+        log "Varnish service is not active."
+        return 1
+    fi
+
+    log "Testing Varnish configuration..."
+    if ! varnishd -C -f /etc/varnish/default.vcl; then
+        log "Varnish configuration test failed."
+        return 1
+    fi
+
+    log "Checking Varnish stats..."
+    if ! varnishstat -1; then
+        log "Failed to retrieve Varnish stats."
+        return 1
+    fi
+
+    log "Stopping Varnish service..."
+    if ! systemctl stop varnish; then
+        log "Failed to stop Varnish service."
+        return 1
+    fi
+
+    log "Varnish functionality test passed successfully."
+    return 0
+}
+
+# Main script execution
+main() {
+    log "Starting Varnish test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_varnish_installed; then
+        if ! install_varnish; then
+            return 1
+        fi
+    fi
+
+    log "Verifying Varnish installation again..."
+    if ! is_varnish_installed; then
+        echo "Varnish installation verification failed."
+        return 1
+    fi
+
+
+    PACKAGE_VERSION=$(varnishd -V 2>&1 | grep -oP 'varnish-\K\d+\.\d+\.\d+' | head -1) || PACKAGE_VERSION="Unknown"
+
+    cd "$original_dir"
+    if test_varnish_functionality; then
+        log "Varnish is functioning correctly."
+        exit_code=0
+    else
+        log "Varnish is not functioning correctly."
+        exit_code=1
+    fi
+    # Clean up
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+    log "Varnish test script completed."
+
+    return $exit_code
+}
+
+# Run the main function
+main

--- a/openkylin/zookeeper/metadata.sh
+++ b/openkylin/zookeeper/metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PACKAGE_NAME="zookeeper"
+PACKAGE_VERSION=$(/opt/zookeeper/bin/zkServer.sh version 2>&1 | grep -oP 'version \K[0-9.]+' | head -1)
+PACKAGE_PRETTY_NAME="ZooKeeper"
+PACKAGE_TYPE="Distributed Coordination Service"
+PACKAGE_DESCRIPTION="A high-performance coordination service for distributed applications"
+
+echo $PACKAGE_VERSION
+echo $PACKAGE_PRETTY_NAME
+echo $PACKAGE_TYPE
+echo $PACKAGE_DESCRIPTION

--- a/openkylin/zookeeper/test.sh
+++ b/openkylin/zookeeper/test.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+set -euo pipefail
+original_dir=$(pwd)
+log "Current directory: $original_dir"
+
+temp_dir=$(mktemp -d)
+log "Created temporary directory: $temp_dir"
+cd "$temp_dir"
+
+# Define the package details
+PACKAGE_NAME="zookeeper"
+
+# Function to check if ZooKeeper is installed
+is_zookeeper_installed() {
+    if [ -d "/opt/zookeeper" ] && [ -f "/opt/zookeeper/bin/zkServer.sh" ]; then
+        log "ZooKeeper is installed. Path: /opt/zookeeper"
+        return 0
+    else
+        log "ZooKeeper is not installed."
+        return 1
+    fi
+}
+
+# Function to install ZooKeeper
+install_zookeeper() {
+    log "Attempting to install ZooKeeper..."
+    export DEBIAN_FRONTEND=noninteractive
+    # Install Java if not already installed
+    if ! command -v java >/dev/null 2>&1; then
+        log "Java not found. Installing OpenJDK..."
+        sudo apt-get update
+        if ! sudo apt-get install -y openjdk-*-jdk; then
+            echo "Failed to install Java."
+            return 1
+        fi
+    fi
+
+    # Download and install ZooKeeper
+    local zk_version="3.9.2"
+    local zk_url="https://dlcdn.apache.org/zookeeper/zookeeper-${zk_version}/apache-zookeeper-${zk_version}-bin.tar.gz"
+    
+    if ! curl -o zookeeper.tar.gz "$zk_url"; then
+        # use curl since wget may not be present on certain systems
+        echo "Failed to download ZooKeeper."
+        return 1
+    fi
+
+    if ! sudo tar -xzf zookeeper.tar.gz -C /opt; then
+        echo "Failed to extract ZooKeeper."
+        return 1
+    fi
+
+    if ! sudo mv /opt/apache-zookeeper-${zk_version}-bin /opt/zookeeper; then
+        echo "Failed to rename ZooKeeper directory."
+        return 1
+    fi
+
+    # Configure ZooKeeper
+    if ! sudo cp /opt/zookeeper/conf/zoo_sample.cfg /opt/zookeeper/conf/zoo.cfg; then
+        echo "Failed to create ZooKeeper configuration."
+        return 1
+    fi
+
+    log "ZooKeeper installation completed. Verifying installation..."
+    if ! is_zookeeper_installed; then
+        echo "ZooKeeper installation failed. ZooKeeper is not available at the expected location."
+        return 1
+    fi
+    log "ZooKeeper installed successfully."
+}
+
+# Function to check system prerequisites
+check_prerequisites() {
+    log "Checking system prerequisites..."
+    if ! command -v java >/dev/null 2>&1; then
+        log "Java is not installed. It will be installed during ZooKeeper installation."
+    fi
+    log "System prerequisites check passed."
+}
+
+# Function to test ZooKeeper functionality
+test_zookeeper_functionality() {
+    # TODO: check if zookeeper server is already running
+    
+    log "Starting ZooKeeper server..."
+    if ! sudo /opt/zookeeper/bin/zkServer.sh start; then
+        log "Failed to start ZooKeeper server."
+        return 1
+    fi
+
+    sleep 5  # Give some time for ZooKeeper to start
+
+    log "Checking ZooKeeper server status..."
+    if ! sudo /opt/zookeeper/bin/zkServer.sh status; then
+        log "ZooKeeper server is not running properly."
+        return 1
+    fi
+
+    log "Testing ZooKeeper client connection..."
+    echo "stat" | nc localhost 2181 > /dev/null
+    if [ $? -ne 0 ]; then
+        log "Failed to connect to ZooKeeper server."
+        return 1
+    fi
+
+    log "Stopping ZooKeeper server..."
+    if ! sudo /opt/zookeeper/bin/zkServer.sh stop; then
+        log "Failed to stop ZooKeeper server."
+        return 1
+    fi
+
+    log "ZooKeeper functionality test passed successfully."
+    return 0
+}
+
+# Main script execution
+main() {
+    log "Starting ZooKeeper test script..."
+
+    if ! check_prerequisites; then
+        return 1
+    fi
+
+    if ! is_zookeeper_installed; then
+        if ! install_zookeeper; then
+            return 1
+        fi
+    fi
+
+    log "Verifying ZooKeeper installation again..."
+    if ! is_zookeeper_installed; then
+        echo "ZooKeeper installation verification failed."
+        return 1
+    fi
+
+    PACKAGE_VERSION=$(/opt/zookeeper/bin/zkServer.sh version 2>&1 | grep -oP 'version \K[0-9.]+' | head -1) || PACKAGE_VERSION="Unknown"
+
+    cd "$original_dir"
+    if test_zookeeper_functionality; then
+        log "ZooKeeper is functioning correctly."
+        exit_code=0
+    else
+        log "ZooKeeper is not functioning correctly."
+        exit_code=1
+    fi
+    # Clean up
+    rm -rf "$temp_dir"
+    log "Cleaned up temporary directory."
+    log "ZooKeeper test script completed."
+
+    return $exit_code
+}
+
+# Run the main function
+main


### PR DESCRIPTION
+ Reused debian test scripts to openkylin
+ `source {}/{} && echo $PACKAGE_VERSION && echo $PACKAGE_PRETTY_NAME && echo $PACKAGE_TYPE && echo $PACKAGE_DESCRIPTION` can output 8 lines bring error in `remote.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入多个新的脚本文件，用于管理和测试不同软件包（如 Apache、Clang、CMake、Docker、Erlang 和 GCC）的安装和元数据提取。
	- 新增配置文件 `config.toml`，用于远程测试环境的设置。

- **修复**
	- 更新 `.gitignore` 文件以忽略更多文件类型。

- **文档**
	- 每个新脚本都包括功能描述，确保用户了解其用途和操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->