### PR TITLE
refactor: avoid unnecessary String allocations

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -56,7 +56,7 @@ pub fn aggregate_reports(
 
         for &package in packages
             .iter()
-            .filter(|p| packages_of_distro.contains(&String::from(**p)))
+            .filter(|p| packages_of_distro.iter().any(|pkg| p == &pkg))
         {
             let report_path = dir.join(format!("{}/{}/report.json", distro, package));
             if let Ok(file) = File::open(&report_path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ fn run_tests(
         let packages_of_distro = utils::get_packages(distro, dir).unwrap_or_default();
         for package in packages
             .iter()
-            .filter(|p| packages_of_distro.contains(&String::from(**p)))
+            .filter(|p| packages_of_distro.iter().any(|pkg| p == &pkg))
         {
             let mut skipped_scripts = Vec::new();
 
@@ -265,7 +265,7 @@ fn run_tests(
             }
 
             if let Some(skip_packages) = &distro_config.skip_packages {
-                if skip_packages.contains(&package.to_string()) {
+                if skip_packages.iter().any(|pkg| pkg == package) {
                     info!("Skipping test for {}/{}", distro, package);
                     continue;
                 }

--- a/src/test_runner/remote.rs
+++ b/src/test_runner/remote.rs
@@ -221,9 +221,9 @@ impl TestRunner for RemoteTestRunner {
         // Upload prerequisite.sh (optional) to remote server
         let prerequisite_path = Path::new(dir).join(format!("{}/prerequisite.sh", distro));
         if Path::new(&prerequisite_path).exists() {
-            let remote_prerequisite_path = "/tmp/prerequisite.sh".to_string();
+            let remote_prerequisite_path = "/tmp/prerequisite.sh";
             let mut remote_file = sess.scp_send(
-                Path::new(&remote_prerequisite_path),
+                Path::new(remote_prerequisite_path),
                 0o644,
                 std::fs::metadata(&prerequisite_path)?.len(),
                 None,
@@ -290,12 +290,11 @@ impl TestRunner for RemoteTestRunner {
             let test_passed = result.exit_status == 0;
             all_tests_passed &= test_passed;
 
-            let output = &result.output;
             debug!("Command: {}", result.command);
             debug!("{:?}", &result);
             test_results.push(TestResult {
-                test_name: script.to_string(),
-                output: output.to_string(),
+                test_name: script,
+                output: result.output,
                 passed: test_passed,
             });
         }
@@ -316,7 +315,6 @@ impl TestRunner for RemoteTestRunner {
                 let metadata_output = self.run_command(&sess, &metadata_command)?;
                 let metadata_vec: Vec<String> = metadata_output
                     .output
-                    .to_string()
                     .lines()
                     .map(|line| line.to_string())
                     .collect();

--- a/src/testscript_manager.rs
+++ b/src/testscript_manager.rs
@@ -63,16 +63,19 @@ impl TestScriptManager {
                 let final_path = path.to_str().unwrap_or_default().to_string();
                 let file_name = path.file_name();
 
-                if skip_scripts.contains(&file_name.unwrap().to_string_lossy().to_string()) {
+                if skip_scripts
+                    .iter()
+                    .any(|s| s.as_str() == file_name.unwrap())
+                {
                     log::debug!("skipped {}", file_name.unwrap().to_string_lossy());
                     continue;
                 }
 
-                if file_name.is_some_and(|name| name == std::ffi::OsStr::new(METADATA_SCRIPT_NAME))
-                {
-                    metadata_script = Some(final_path);
-                } else {
-                    test_scripts.push(final_path);
+                match file_name {
+                    Some(name) if name == METADATA_SCRIPT_NAME => {
+                        metadata_script = Some(final_path)
+                    }
+                    _ => test_scripts.push(final_path),
                 }
             }
         }


### PR DESCRIPTION
There are some unnecessary `String` allocations, including but not limited to `String::from()` and `.to_string()`.

When the argument of `.contains()` is not `&T`, [Rust Doc](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.contains) recommends using `iter().any`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 优化了包过滤和脚本处理的逻辑，使用更加惯用的Rust迭代器方法
	- 简化了字符串处理和路径处理的代码

- **代码改进**
	- 改进了测试运行器和测试脚本管理器中的代码可读性
	- 移除了不必要的字符串转换

- **方法签名变更**
	- `TestScriptManager` 的 `new` 方法增加了一个工作目录参数

这些更改旨在提高代码质量和性能，但不会改变整体功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->